### PR TITLE
v0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-phone-input",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Phone input box for React Native",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
need to bump version to resolve yarn skipping install

warning Pattern ["react-native-phone-input@ubiquity6/react-native-phone-input#281d25d3ff283269d1aed8addcb8179006e0d767"] is trying to unpack in the same destination "/usr/local/share/.cache/yarn/v4/npm-react-native-phone-input-0.2.0/node_modules/react-native-phone-input" as pattern ["react-native-phone-input@ubiquity6/react-native-phone-input#6779125d080b01dfe7df1c42b6120fb016a921e4"]. This could result in non-deterministic behavior, skipping.